### PR TITLE
THe introduction of a unique_id in the configuration file.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,8 @@
 # Teletask Integration for Home Assistant
 
-
 ## Installation
 
-You can only be logged into the ComNav/ZeroWire hub with the same user *once*; a subsequent login with the same user logs out the other. Since this tool/software actively polls and maintains a login session to your Hub, it can prevent you from being able to log into at the same time elsewhere (via it's website).  **It is strongly recommended that you create a second user account on your Hub dedicated to just this service.**
+You can only be logged into the ComNav/ZeroWire hub with the same user _once_; a subsequent login with the same user logs out the other. Since this tool/software actively polls and maintains a login session to your Hub, it can prevent you from being able to log into at the same time elsewhere (via it's website). **It is strongly recommended that you create a second user account on your Hub dedicated to just this service.**
 
 ### From HACS
 
@@ -18,7 +17,6 @@ You can only be logged into the ComNav/ZeroWire hub with the same user *once*; a
 2. Copy contents of the archive/repo into your `/config` directory.
 3. Restart your Home Assistant.
 4. Add "Teletask" integration in Home Assistant's config file 'configuration.yaml'
-
 
 ## Configuration
 
@@ -35,38 +33,46 @@ teletask:
   port: 55957
 
   switch:
-  - doip_component: relay
-    address: "1"
-    name: "Electrical Socket Carport"
+    - doip_component: relay
+      address: "1"
+      name: "Electrical Socket Carport"
+      unique_id: { guid }
 
   light:
-  - doip_component: relay
-    address: "1"
-    name: "Bulb Living Room"
+    - doip_component: relay
+      address: "1"
+      name: "Bulb Living Room"
+      unique_id: { guid }
 
-  - doip_component: relay
-    address: "31"
-    brightness_address: "1"
-    name: "Led Strip Bedroom 1"
+    - doip_component: relay
+      address: "31"
+      brightness_address: "1"
+      name: "Led Strip Bedroom 1"
+      unique_id: { guid }
 ```
 
 ### Global Attributes
-| name | type | mandatory field | description |
-| ---- | ---- | --------------- | ----------- |
-| host | String | Yes | The IP address or the Hostname where the Teletask DoIP API is running |
-| port | Integer | Yes | The Porrt where the Teletask DoIP API is listening on (default is port 55957) |
+
+| name | type    | mandatory field | description                                                                   |
+| ---- | ------- | --------------- | ----------------------------------------------------------------------------- |
+| host | String  | Yes             | The IP address or the Hostname where the Teletask DoIP API is running         |
+| port | Integer | Yes             | The Porrt where the Teletask DoIP API is listening on (default is port 55957) |
 
 ### Light Attributes
-| name | type | mandatory field | description |
-| ---- | ---- | --------------- | ----------- |
-| doip_component | String | Yes | Possible Values: `relay`, `locmood`, `genmood` and `flag` |
-  address | String | Yes | The identifier on the Teletask DoIP Bus for the doip_component type |
-| brightness_address | String |  No | The identifier on the Teletask DoIP Bus for the type 'dimmer' |
-| description | String | Yes | Friendly Name |
+
+| name               | type   | mandatory field | description                                                         |
+| ------------------ | ------ | --------------- | ------------------------------------------------------------------- |
+| doip_component     | String | Yes             | Possible Values: `relay`, `locmood`, `genmood` and `flag`           |
+| address            | String | Yes             | The identifier on the Teletask DoIP Bus for the doip_component type |
+| brightness_address | String | No              | The identifier on the Teletask DoIP Bus for the type 'dimmer'       |
+| name               | String | Yes             | Friendly Name                                                       |
+| unique_id          | String | No              | Unique Identifier for the entity (for example a guid).              |
 
 ### Switch Attributes
-| name | type | mandatory field | description |
-| ---- | ---- | --------------- | ----------- |
-| doip_component | String | Yes | Possible Values: `relay`, `locmood`, `genmood` and `flag` |
-  address | String | Yes | The identifier on the Teletask DoIP Bus for the doip_component type |
-| description | String | Yes | Friendly Name |
+
+| name           | type   | mandatory field | description                                                         |
+| -------------- | ------ | --------------- | ------------------------------------------------------------------- |
+| doip_component | String | Yes             | Possible Values: `relay`, `locmood`, `genmood` and `flag`           |
+| address        | String | Yes             | The identifier on the Teletask DoIP Bus for the doip_component type |
+| name           | String | Yes             | Friendly Name                                                       |
+| unique_id      | String | No              | Unique Identifier for the entity (for example a guid).              |

--- a/custom_components/teletask/light.py
+++ b/custom_components/teletask/light.py
@@ -35,15 +35,17 @@ async def async_setup_platform(hass, config, async_add_entities, discovery_info)
         )
         await light.current_state()
         hass.data[DOMAIN].teletask.devices.add(light)
-        async_add_entities([TeletaskLight(light)])
+        async_add_entities([TeletaskLight(light, config.get("unique_id"))])
 
 class TeletaskLight(LightEntity):
     """Representation of a Teletask light."""
 
-    def __init__(self, device):
+    def __init__(self, device, unique_id):
         """Initialize of Teletask light."""
         self.device = device
         self.teletask = device.teletask
+        if unique_id is not None:
+            self._attr_unique_id = unique_id
 
     @callback
     def async_register_callbacks(self):

--- a/custom_components/teletask/switch.py
+++ b/custom_components/teletask/switch.py
@@ -30,16 +30,18 @@ async def async_setup_platform(hass, config, async_add_entities, discovery_info)
         )
         await switch.current_state()
         hass.data[DOMAIN].teletask.devices.add(switch)
-        async_add_entities([TeletaskSwitch(switch)])
+        async_add_entities([TeletaskSwitch(switch, config.get("unique_id"))])
 
 
 class TeletaskSwitch(SwitchEntity):
     """Representation of a Teletask Switch."""
 
-    def __init__(self, device):
+    def __init__(self, device, unique_id):
         """Initialize of Teletask Switch."""
         self.device = device
         self.teletask = device.teletask
+        if unique_id is not None:
+            self._attr_unique_id = unique_id
 
     @callback
     def async_register_callbacks(self):


### PR DESCRIPTION
I introduced the use of the unique_id in the configuration file (this seems like a common practise in HA).  This ensures the entities can be configured in HA (setting the icon, assigning it to a room).  

For example...
`
host: 192.168.1.101
port: 55957

switch:
  - doip_component: relay
    address: "1"
    name: "Office Teletask Plug"
    unique_id: 4cf2ee7a-a3e2-11ed-a8fc-0242ac120002

light:
  - doip_component: relay
    address: "2"
    name: "Office Teletask Spots"
    unique_id: 54e3a6ec-a3e2-11ed-a8fc-0242ac120002
`

I modified the light.py and switch.py files to read the unique_id parameter in the setup of the respective lights and switchs for the Teletask platform. In the _init_ of the respective TeletaskLight and TeletaskSwitch object, I receive and set the unique_id if it is available. 

I've also updated the README.md file. 

This is fully tested on my platform.